### PR TITLE
Clarify acl:Control usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+##### v0.1.1
+
+- Change the [Referring to Resources](#referring-to-resources) section --
+  the recommended solution is simply to use `acl:Control`, and not refer
+  to the ACL resource itself in its own contents.
+- Remove the phrasing that WAC does not privilege the ACL resources.
+- Clarify that `acl:Control` gives access even to *read* the ACL resource.
+  Without that permission, a user cannot read the resource.
+
 ##### v0.1.0
 
 First draft of spec, as of Apr 2016.


### PR DESCRIPTION
- Change the [Referring to Resources](#referring-to-resources) section --
  the recommended solution is simply to use `acl:Control`, and not refer
  to the ACL resource itself in its own contents.
- Remove the phrasing that WAC does not privilege the ACL resources.
- Clarify that `acl:Control` gives access even to *read* the ACL resource.
  Without that permission, a user cannot read the resource.