### PR TITLE
Timestamps and ACL caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ modified and if possible, an estimate of future validity, to help
 systems that manage authorizations. For this purpose, properties from
 the
 [Dublin Core metadata terms vocabulary](http://dublincore.org/documents/dcmi-terms/)
-should be used, with the namespace `http://purl.org/dc/terms/`,
+should be used: 
 `dc:issued`, `dc:modified` and `dc:valid` with a valid `xsd:dateTime`
 data type should be used, respectively.
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,33 @@ and Control) to one of her web resources, located at
                   acl:Control.
 ```
 
+## Timestamps and temporal validity
+
+To help consuming systems manage authorizations, they should provide
+timestamps indicating time of issue, last modified and if possible, an
+estimate of future validity. For this purpose, properties from the
+[Dublin Core metadata terms vocabulary](http://dublincore.org/documents/dcmi-terms/)
+should be used, with the namespace `http://purl.org/dc/terms/`,
+`dc:issued`, `dc:modified` and `dc:valid` with a valid `xsd:dateTime`
+data type should be used, respectively.
+
+For example, to authorize Alice with read access to a certain Web
+resource, and commit to that it is also valid 5 years from last
+modification, it should be given as:
+
+@prefix  acl:  <http://www.w3.org/ns/auth/acl#>.
+@prefix  dc:   <http://purl.org/dc/terms/>.
+@prefix  xsd:  <http://www.w3.org/2001/XMLSchema#>.
+
+<#authorization1>
+    a             acl:Authorization;
+    dc:issued     "2013-09-11T07:18:19+0000"^^xsd:dateTime;
+    dc:modified   "2019-02-12T16:15:15+0000"^^xsd:dateTime;
+    dc:valid      "2024-02-12T16:15:15+0000"^^xsd:dateTime;
+    acl:agent     <https://alice.databox.me/profile/card#me>;  # Alice's WebID
+    acl:accessTo  <https://alice.databox.me/docs/file2>;
+    acl:mode      acl:Read.
+
 ## Describing Agents
 
 In WAC, we use the term *Agent* to identify *who* is allowed access to various
@@ -266,13 +293,14 @@ Corresponding `work-groups` Group Listing document:
 @prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
 @prefix     dc:  <http://purl.org/dc/terms/>.
+@prefix    xsd:  <http://www.w3.org/2001/XMLSchema#>.
 
 <>  a  acl:GroupListing.
 
 <#Accounting>
     a                vcard:Group;
     vcard:hasUID     <urn:uuid:8831CBAD-1111-2222-8563-F0F4787E5398:ABGroup>;
-    dc:created       "2013-09-11T07:18:19+0000"^^xsd:dateTime;
+    dc:issued        "2013-09-11T07:18:19+0000"^^xsd:dateTime;
     dc:modified      "2015-08-08T14:45:15+0000"^^xsd:dateTime;
 
     # Accounting group members:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ applications that provides ACL editing are encouraged to help users
 set this sensibly, and to warn users that some systems may not update
 their ACL, and therefore yield unexpected results.
 
+Servers that evaluate authorizations to grant or deny access to
+resources and uses an ACL cache, must ensure that the ACL cache uses a
+current authorization even in the case that `dc:valid` has been set to
+a future date.
+
 
 ### HTTP caching implementation
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ This allows specialised clients or proxies to cache individual
 authorizations based on the RDF metadata alone, and for legacy Web
 caches to use cached copies of ACL Resources in their operations.
 
+Clients and proxies that
+[calculate heuristic freshness](https://tools.ietf.org/html/rfc7234#section-4.2.2)
+should take care to ensure the user is not lead to believe that an
+authorization is different from the actual authorization on the
+server.
+
 
 
 ## Describing Agents

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ should be used:
 `dc:issued`, `dc:modified` and `dc:valid` with a valid `xsd:dateTime`
 data type should be used, respectively.
 
-For example, the below example authorizes Alice to have read access to
+For example, the below authorizes Alice to have read access to
 a certain Web resource, and also says that the authorization is valid
 5 years from last modification:
 
@@ -267,7 +267,7 @@ that an ACL Resource may contain several
 `acl:Authorization`s. Therefore, if used, the server must set the
 `Last-Modified` header to the most recent `dc:modified`. Also, if the
 server uses `dc:valid` to set the `Expires` header and/or to compute
-`max-age`, it must use the `dct:valid` that is set to expire
+`max-age`, it must use the `dc:valid` that is set to expire
 first. Note that an ACL cache must be private.
 
 This allows specialised clients or proxies to cache individual
@@ -285,7 +285,7 @@ server always uses the most recent authorization), but can result
 in poor security usability. Developers should in particular be aware of
 these two cases:
 
-  1. A user has previously set a `dct:valid`, but the current user
+  1. A user has previously set a `dc:valid`, but the current user
      decides to modify the time and date even though the authorization
      previously given would still be valid. In this case, the user
      should be warned that some clients may not see the update, and

--- a/README.md
+++ b/README.md
@@ -240,6 +240,27 @@ modification, it should be given as:
     acl:mode      acl:Read.
 ```
 
+Specialised systems may use these RDF metadata statements to perform
+relevant caching operations on individiual authorization resources.
+
+### HTTP caching implementation
+
+Systems should use these times if available to manage ACL caches. If
+the HTTP protocol is used, `dc:modified` should be used for
+[conditional requests](https://tools.ietf.org/html/rfc7232) and
+`dc:valid` for [caching](https://tools.ietf.org/html/rfc7234). Note
+that an ACL Resource may contain several
+`acl:Authorization`s. Therefore, if used, the server must set the
+`Last-Modified` header to the most recent `dc:modified`. Also, if the
+server uses `dc:valid` to set the `Expires` header and/or to compute
+`max-age`, it must use the `dct:valid` that is set to expire
+first. Note that an ACL cache must be private.
+
+This allows specialised clients or proxies to cache individual
+authorizations based on the RDF metadata alone, and for legacy Web
+caches to use cached copies of ACL Resources in their operations.
+
+
 
 ## Describing Agents
 

--- a/README.md
+++ b/README.md
@@ -214,17 +214,18 @@ and Control) to one of her web resources, located at
 
 ## Timestamps and temporal validity
 
-To help consuming systems manage authorizations, they should provide
-timestamps indicating time of issue, last modified and if possible, an
-estimate of future validity. For this purpose, properties from the
+Servers should provide timestamps indicating time of issue, last
+modified and if possible, an estimate of future validity, to help
+systems that manage authorizations. For this purpose, properties from
+the
 [Dublin Core metadata terms vocabulary](http://dublincore.org/documents/dcmi-terms/)
 should be used, with the namespace `http://purl.org/dc/terms/`,
 `dc:issued`, `dc:modified` and `dc:valid` with a valid `xsd:dateTime`
 data type should be used, respectively.
 
-For example, to authorize Alice with read access to a certain Web
-resource, and commit to that it is also valid 5 years from last
-modification, it should be given as:
+For example, the below example authorizes Alice to have read access to
+a certain Web resource, and also says that the authorization is valid
+5 years from last modification:
 
 ```ttl
 @prefix  acl:  <http://www.w3.org/ns/auth/acl#>.
@@ -248,8 +249,7 @@ While `dc:issued` and `dc:modified` can be set automatically, setting
 `dc:valid` requires a commitment from the author of the authorization
 that it will not change before the indicated time. Developers of
 applications that provides ACL editing are encouraged to help users
-set this sensibly, and to warn users that some systems may not update
-their ACL, and therefore yield unexpected results.
+set this sensibly.
 
 Servers that evaluate authorizations to grant or deny access to
 resources and uses an ACL cache, must ensure that the ACL cache uses a
@@ -273,13 +273,6 @@ first. Note that an ACL cache must be private.
 This allows specialised clients or proxies to cache individual
 authorizations based on the RDF metadata alone, and for legacy Web
 caches to use cached copies of ACL Resources in their operations.
-
-Clients and proxies that
-[calculate heuristic freshness](https://tools.ietf.org/html/rfc7234#section-4.2.2)
-should take care to ensure the user is not lead to believe that an
-authorization is different from the actual authorization on the
-server.
-
 
 
 ## Describing Agents

--- a/README.md
+++ b/README.md
@@ -274,6 +274,28 @@ This allows specialised clients or proxies to cache individual
 authorizations based on the RDF metadata alone, and for legacy Web
 caches to use cached copies of ACL Resources in their operations.
 
+### Implementation notes
+
+Applications may use cached authorizations to improve responsiveness
+and usability. Since servers must always use the most recent
+authorizations for operations, discrepancies between a client/proxy
+cache and what the server uses may arise if an application uses a
+stale authorization. That will not be security critical (since the the
+server always uses the most recent authorization), but can result
+in poor security usability. Developers should in particular be aware of
+these two cases:
+
+  1. A user has previously set a `dct:valid`, but the current user
+     decides to modify the time and date even though the authorization
+     previously given would still be valid. In this case, the user
+     should be warned that some clients may not see the update, and
+     so, it will be confusing to its users.
+  1. Clients and proxies might use the timestamps to calculate heuristic
+     freshness
+     [(like suggested in the HTTP specification)](https://tools.ietf.org/html/rfc7234#section-4.2.2).
+     Like above, this may also result in that an expired authorization
+     is provided to applications. Heuristic freshness should only be
+     used with extreme care.
 
 ## Describing Agents
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ For example, to authorize Alice with read access to a certain Web
 resource, and commit to that it is also valid 5 years from last
 modification, it should be given as:
 
+```ttl
 @prefix  acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  dc:   <http://purl.org/dc/terms/>.
 @prefix  xsd:  <http://www.w3.org/2001/XMLSchema#>.
@@ -237,6 +238,8 @@ modification, it should be given as:
     acl:agent     <https://alice.databox.me/profile/card#me>;  # Alice's WebID
     acl:accessTo  <https://alice.databox.me/docs/file2>;
     acl:mode      acl:Read.
+```
+
 
 ## Describing Agents
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,9 @@ the following issues:
 Possible future methods for a server to find out whether a given agent is a
 member of s group are a matter for future research and possible addition here.
 
+Group listings may also use timestamp predicates, and be cached along
+with ACL resources.
+
 ### Public Access (All Agents)
 
 To specify that you're giving a particular mode of access to *everyone*

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ modification, it should be given as:
 @prefix  dc:   <http://purl.org/dc/terms/>.
 @prefix  xsd:  <http://www.w3.org/2001/XMLSchema#>.
 
-<#authorization1>
+<#authorization2>
     a             acl:Authorization;
     dc:issued     "2013-09-11T07:18:19+0000"^^xsd:dateTime;
     dc:modified   "2019-02-12T16:15:15+0000"^^xsd:dateTime;

--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ Next](https://www.w3.org/community/ldpnext/)) type systems, such as the
 3. [ACL Inheritance Algorithm](#acl-inheritance-algorithm)
 4. [Representation Format](#representation-format)
 5. [Example WAC Document](#example-wac-document)
-6. [Describing Agents](#describing-agents)
+6. [Timestamps and temporal validity](#timestamps-and-temporal-validity)
+7. [Describing Agents](#describing-agents)
   * [Singular Agent](#singular-agent)
   * [Groups](#groups-of-agents)
   * [Public Access (all Agents)](#public-access-all-agents)
   * [Anyone logged on (Authenticated Agents)](#authenticated-agents-anyone-logged-on)
   * [Referring to Origins, i.e. Web Apps](#referring-to-origins-ie-web-apps)
-7. [Referring to Resources](#referring-to-resources)
-8. [Modes of Access](#modes-of-access)
-9. [Default (Inherited) Authorizations](#default-inherited-authorizations)
-10. [Not Supported by Design](#not-supported-by-design)
+8. [Referring to Resources](#referring-to-resources)
+9. [Modes of Access](#modes-of-access)
+10. [Default (Inherited) Authorizations](#default-inherited-authorizations)
+11. [Not Supported by Design](#not-supported-by-design)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ modification, it should be given as:
 Specialised systems may use these RDF metadata statements to perform
 relevant caching operations on individiual authorization resources.
 
+While `dc:issued` and `dc:modified` can be set automatically, setting
+`dc:valid` requires a commitment from the author of the authorization
+that it will not change before the indicated time. Developers of
+applications that provides ACL editing are encouraged to help users
+set this sensibly, and to warn users that some systems may not update
+their ACL, and therefore yield unexpected results.
+
+
 ### HTTP caching implementation
 
 Systems should use these times if available to manage ACL caches. If

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Corresponding `work-groups` Group Listing document:
 # Contents of https://alice.example.com/work-groups
 @prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
+@prefix     dc:  <http://purl.org/dc/terms/>.
 
 <>  a  acl:GroupListing.
 


### PR DESCRIPTION
I started thinking about the design of an ACL cache, and figured some metadata set on the authorizations, using DC properties could help with that. 

This proposal helps both with caching individual authorizations, like a specialized reverse proxy or a Solid app could, as well as recommendations for Solid servers to implement so that legacy HTTP caches may cache ACL resources.

I think this should be in the WAC spec, so I submit it as a proposal.