### PR TITLE
What headers should a client be allowed to send?

### DIFF
--- a/Background.md
+++ b/Background.md
@@ -47,9 +47,9 @@ on a "Pre-flight" OPTIONS request which is inserted before the main request.  So
 As well as blocking the data, the CORS system blocks headers from the server to the web app.
 To prevent this this, the server must send another  [header](https://www.w3.org/TR/cors/#access-control-allow-headers-response-header):
 ```
-Access-Control-Allow-Headers: Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate
+Access-Control-Allow-Headers: Accept, Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate
 ```
-This must include things like the Link: header which are normal headers blocked by the browser, and also any new headers the app and serve are using for any purpose.
+This must include things like the Link: header which are normal headers blocked by the browser, and also any new headers the app and server are using for any purpose.
 
 ### Method blocking
 

--- a/Background.md
+++ b/Background.md
@@ -37,7 +37,7 @@ This meant that anyone publishing public data has to add
 Access-control-allow-Origin: *
 ```
 in any response.  This meant a huge amount of work for random open data publishers
-all over the web, an effort which in many cases for many reasonable reasons was not done, leaving the data available to browsers, but unavailable to web apps.
+all over the web, an effort which in many cases for many reasonable reasons was not done, leaving the data available to web apps, but unavailable to browsers.
 
 The browser actually looks for these headers not on the request itself, but in
 on a "Pre-flight" OPTIONS request which is inserted before the main request.  So while the developer may see in the browser console only the main request, the number of round trips has in fact increased.


### PR DESCRIPTION
I see https://solid.github.io/web-access-control-spec/Background as a great background document on Cross Origin Resource Sharing.  The document proposes a default set of headers to be allowed by all servers in the ecosystem.

With this pull request I would like to open the discussion to accepting more headers by default. For me in particular, the Accept header was lacking.