### PR TITLE
Include Editors and Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Next](https://www.w3.org/community/ldpnext/)) type systems, such as the
 
 **Current Spec version:** `v.0.5.0` (see [CHANGELOG.md](CHANGELOG.md))
 
+**Editor** Solid Specification Repository Manager
+
+**Contributors** 
+
 ## Table of Contents
 
 1. [Overview](#overview)


### PR DESCRIPTION
At the W3C Solid Community Group call on the 11th April it was decided to include the spec editor and contributors to each of the Solid specification repositories. The editor is clearly the Solid Specifications Repository Manager. 

Please join to the conversation on what you think should be the criteria to be included as a contributor on https://github.com/solid/solid-spec/pull/155

This is a good place to put your name if you would like to be included as a contributor to this repository.