### PR TITLE
Fix  missing prefixes in agentGroup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Corresponding `work-groups` Group Listing document:
 ```ttl
 # Contents of https://alice.example.com/work-groups
 @prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
+@prefix     dc:  <http://purl.org/dc/elements/1.1/>.
 @prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
 
 <#Accounting>

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Corresponding `work-groups` Group Listing document:
 @prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
 @prefix     dc:  <http://purl.org/dc/elements/1.1/>.
 @prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
+@prefix    xsd:  <http://www.w3.org/2001/XMLSchema#>.
 
 <#Accounting>
     a                vcard:Group;


### PR DESCRIPTION
my implementation at https://github.com/inrupt/wac-ldp choked on this when I tried to use it as a test fixture :)