### PR TITLE
Clarify matching conditions

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,13 +765,13 @@ content: "";
 
                       <p>As container resources and member resources are hierarchically organised, requests to perform operations on resources are in the context of the applicable container (<cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite>).</p>
 
-                      <p id="server-read-resource">When an operation requests to read a resource, the server MUST match an Authorization allowing the <code>acl:Read</code> access privilege on the resource.</p>
+                      <p id="server-read-resource">A request for an operation to read a resource MUST be denied if the server cannot match an Authorization allowing the <code>acl:Read</code> access privilege on that resource.</p>
 
-                      <p id="server-create-operation">When an operation requests to create a resource as a member of a container resource, the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege (as needed by the operation) on the resource to be created.</p>
+                      <p id="server-create-operation">A request for an operation to create a resource as a member of a container resource MUST be denied if the server cannot match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on that resource.</p>
 
-                      <p id="server-update-operation">When an operation requests to update a resource, the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the resource.</p>
+                      <p id="server-update-operation">A request for an operation to update a resource MUST be denied if the server cannot match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on that resource.</p>
 
-                      <p id="server-delete-operation">When an operation requests to delete a resource, the server MUST match Authorizations allowing the <code>acl:Write</code> access privilege on the resource and the containing container.</p>
+                      <p id="server-delete-operation">A request for an operation to delete a resource MUST be denied if the server cannot match Authorizations allowing the <code>acl:Write</code> access privilege on that resource and its containing container.</p>
 
                       <div class="note" id="container-permissions" inlist="" rel="schema:hasPart" resource="#container-permissions">
                         <h5 property="schema:name"><span>Note</span>: Container Permissions</h5>


### PR DESCRIPTION
Following the discussion at https://github.com/solid/web-access-control-spec/pull/95#issuecomment-899087663, I am hereby suggesting language clarifications for authorization matches.

## Issues with the existing text

The existing language reads:

> When an operation requests […], the server MUST match an Authorization […]

1. If taken literally (as we would with a spec), this means the following. If a request comes in, and the server does not match an Authorization, then the server is not compliant with the spec (because it MUST match).
2. It is unclear whether this is a necessary or sufficient condition (which gave rise to #95).

## Proposed solution
By rephrasing the relevant sentences to:

> A request for an operation to […] MUST be denied if the server cannot match an Authorization […]

This phrasing:
1. Is correct when taken literally.
2. Is a necessary condition, but not sufficient (there can be other reasons to deny).
