### PR TITLE
Clarify http-method-access-mode-mapping note for PUT

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@ content: "";
 
                           <p>The HTTP <code>POST</code> can be used to create a new resource in a container or add information to existing resources (but not remove resources or its contents) with either <code>acl:Append</code> or <code>acl:Write</code>.</p>
 
-                          <p>As the HTTP <code>PUT</code> method requests to create or replace the resource state, the <code>acl:Write</code> access mode would be required.</p>
+                          <p>As the HTTP <code>PUT</code> method requests to create or replace the resource state, the <code>acl:Write</code> access mode is required to replace an existing resource, but to create a new resource, access to the container can be either <code>acl:Append</code> or <code>acl:Write</code>.</p>
 
                           <p>As the processing of HTTP <code>PATCH</code> method requests depends on the request semantics and content, <code>acl:Append</code> can allow requests using SPARQL 1.1 Update’s [<cite><a class="bibref" href="#bib-sparql11-update">SPARQL11-UPDATE</a></cite>] <code>INSERT DATA</code> operation but not <code>DELETE DATA</code>, whereas <code>acl:Write</code> would allow both operations.</p>
 


### PR DESCRIPTION
This is a [correction class 2](https://www.w3.org/2023/Process-20230612/#class-2) change updating the Note section (non-normative) [HTTP Method and Access Mode Mapping](https://solid.github.io/web-access-control-spec/#http-method-access-mode-mapping).

Resolves https://github.com/solid/web-access-control-spec/issues/122