### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@ content: "";
             <div datatype="rdf:HTML" property="schema:description">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Editor’s Draft</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Editor’s Draft</em>. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an <em>Editor’s Draft</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.