### PR TITLE
Remove contributors, add authors

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,17 +159,17 @@ content: "";
             <dd><a href="https://solidproject.org/TR/2022/wac-20220705" rel="rel:predecessor-version">https://solidproject.org/TR/2022/wac-20220705</a></dd>
           </dl>
 
-          <div id="authors">
-            <dl id="author-name">
-              <dt>Editors</dt>
-              <dd id="Sarven-Capadisli"><span about="" rel="schema:creator schema:editor schema:author"><span about="https://csarven.ca/#i" typeof="schema:Person"><a href="https://csarven.ca/" rel="schema:url"><span about="https://csarven.ca/#i" property="schema:name"><span property="schema:givenName">Sarven</span> <span property="schema:familyName">Capadisli</span></span></a></span></span></dd>
-            </dl>
+          <dl id="document-editors">
+            <dt>Editors</dt>
+            <dd id="Sarven-Capadisli"><span about="" rel="schema:creator schema:editor"><span about="https://csarven.ca/#i" typeof="schema:Person"><a href="https://csarven.ca/" rel="schema:url"><span about="https://csarven.ca/#i" property="schema:name"><span property="schema:givenName">Sarven</span> <span property="schema:familyName">Capadisli</span></span></a></span></span></dd>
+          </dl>
 
-            <dl id="document-contributors">
-              <dt>Contributors</dt>
-              <dd id="Tim-Berners-Lee"><span about="" rel="schema:editor schema:author"><span about="https://www.w3.org/People/Berners-Lee/card#i" typeof="schema:Person"><a href="https://www.w3.org/People/Berners-Lee/" rel="schema:url"><span about="https://www.w3.org/People/Berners-Lee/card#i" property="schema:name"><span property="schema:givenName">Tim</span> <span property="schema:familyName">Berners-Lee</span></span></a></span></span></dd>
-            </dl>
-          </div>
+          <dl id="document-authors">
+            <dt>Authors</dt>
+            <dd id="Tim-Berners-Lee"><span about="" rel="schema:author"><span about="https://www.w3.org/People/Berners-Lee/card#i" typeof="schema:Person"><a href="https://www.w3.org/People/Berners-Lee/" rel="schema:url"><span about="https://www.w3.org/People/Berners-Lee/card#i" property="schema:name"><span property="schema:givenName">Tim</span> <span property="schema:familyName">Berners-Lee</span></span></a></span></span></dd>
+            <dd id="Henry-Story"><span about="" rel="schema:author"><span about="https://bblfish.net/profile/card#me" typeof="schema:Person"><a href="https://bblfish.net/" rel="schema:url"><span about="https://bblfish.net/profile/card#me" property="schema:name"><span property="schema:givenName">Henry</span> <span property="schema:familyName">Story</span></span></a></span></span></dd>
+            <dd><a about="" rel="schema:author" resource="https://csarven.ca/#i" href="https://csarven.ca/">Sarven Capadisli</a></dd>
+          </dl>
 
           <dl id="document-created">
             <dt>Created</dt>


### PR DESCRIPTION
* Moves TimBL from contributor to author.
* Adds Henry and Sarven as co-authors.

Going forward in the Solid CG, "contributor" is being used liberally for anyone contributing to the specification through the CG CLA agreement. It is not a specific role in the spec like an editor or an author. Brief explanation for the changes:
* Tim as co-author, which is more appropriate than contributor considering his key technical and architectural contributions to making WAC happen.
* Henry as co-author for his technical and architectural contributions (including https://www.w3.org/wiki/WebAccessControl and everywhere else) which helped to materialise WAC.
* Sarven (myself) as co-author for writing up this specification.

If I've left out anyone with significant editor and/or author-level contributions to this specification, please pardon me, it wasn't intentional. Please chime-in.


---

[Preview](https://htmlpreview.github.io/?https://github.com/solid/web-access-control-spec/blob/7314f2e3921a81209f69b3640f3088f89490206e/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fweb-access-control-spec%2Fea5c32a59e7a2f20a04cb14aecbbe65627969773%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fweb-access-control-spec%2F7314f2e3921a81209f69b3640f3088f89490206e%2Findex.html)