### PR TITLE
Further clarify requirements for PUT-to-create and PATCH-to-create

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,10 +805,10 @@ content: "";
                             <dd>The HTTP <code>POST</code> can be used to create a new resource in a container or add information to existing resources (but not remove resources or its contents) with either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
 
                             <dt id="http-put"><code>PUT</code></dt>
-                            <dd>As the HTTP <code>PUT</code> method requests to create or replace the resource state, the <code>acl:Write</code> access mode is required to replace an existing resource, but to create a new resource, access to the container additionally needs to be either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
+                            <dd>The HTTP <code>PUT</code> method requests to create or replace the resource state. <i>Creating</i> a new resource requires <code>acl:Append</code> and/or <code>acl:Write</code> access to the container as well as <code>acl:Write</code> access to the (new) resource. <i>Replacing</i> an existing resource requires only <code>acl:Write</code> access to the resource itself.</dd>
 
                             <dt id="http-patch"><code>PATCH</code></dt>
-                            <dd>As the processing of HTTP <code>PATCH</code> method requests depends on the request semantics and content, <code>acl:Append</code> can allow requests using SPARQL 1.1 Update’s [<cite><a class="bibref" href="#bib-sparql11-update">SPARQL11-UPDATE</a></cite>] <code>INSERT DATA</code> operation but not <code>DELETE DATA</code>, whereas <code>acl:Write</code> would allow both operations. And again, to create a new resource, access to the container additionally needs to be either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
+                            <dd>As the processing of HTTP <code>PATCH</code> method request depends on the request semantics and content, <code>acl:Append</code> can allow requests to <em>insert</em> but not <em>delete<em> operations, whereas <code>acl:Write</code> would allow both operations. To create a new resource, <code>acl:Append</code> or <code>acl:Write</code> access mode to the container is additionally required.</dd>
 
                             <dt id="http-delete"><code>DELETE</code></dt>
                             <dd>As the HTTP <code>DELETE</code> method requests to remove a resource, the <code>acl:Write</code> access mode would be required.</dd>

--- a/index.html
+++ b/index.html
@@ -805,10 +805,10 @@ content: "";
                             <dd>The HTTP <code>POST</code> can be used to create a new resource in a container or add information to existing resources (but not remove resources or its contents) with either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
 
                             <dt id="http-put"><code>PUT</code></dt>
-                            <dd>As the HTTP <code>PUT</code> method requests to create or replace the resource state, the <code>acl:Write</code> access mode is required to replace an existing resource, but to create a new resource, access to the container can be either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
+                            <dd>As the HTTP <code>PUT</code> method requests to create or replace the resource state, the <code>acl:Write</code> access mode is required to replace an existing resource, but to create a new resource, access to the container additionally needs to be either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
 
                             <dt id="http-patch"><code>PATCH</code></dt>
-                            <dd>As the processing of HTTP <code>PATCH</code> method requests depends on the request semantics and content, <code>acl:Append</code> can allow requests using SPARQL 1.1 Update’s [<cite><a class="bibref" href="#bib-sparql11-update">SPARQL11-UPDATE</a></cite>] <code>INSERT DATA</code> operation but not <code>DELETE DATA</code>, whereas <code>acl:Write</code> would allow both operations.</dd>
+                            <dd>As the processing of HTTP <code>PATCH</code> method requests depends on the request semantics and content, <code>acl:Append</code> can allow requests using SPARQL 1.1 Update’s [<cite><a class="bibref" href="#bib-sparql11-update">SPARQL11-UPDATE</a></cite>] <code>INSERT DATA</code> operation but not <code>DELETE DATA</code>, whereas <code>acl:Write</code> would allow both operations. And again, to create a new resource, access to the container additionally needs to be either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
 
                             <dt id="http-delete"><code>DELETE</code></dt>
                             <dd>As the HTTP <code>DELETE</code> method requests to remove a resource, the <code>acl:Write</code> access mode would be required.</dd>


### PR DESCRIPTION
ACL permission requirements are hard to follow even if you spell them out completely, and in this spec text we try to speak in generic terms about them, and only mention the aspects that are worth noting, and that makes it even harder.

I might be getting this wrong because it's all so complex, but here's what I think now after reading the recent comments:

It seems #122 created [some confusion](https://github.com/solid-contrib/web-access-control-tests/pull/56). 

This updates the text to match what we decided [in response to a similar but unrelated confusion](https://github.com/solid/web-access-control-spec/issues/105#issuecomment-1160876522).

At the time we decided not to update the spec text, but now that the spec text is more detailed, the current statement is not correctly conveying that access to both the containing folder and the non-existing resource URL is required.